### PR TITLE
Add support for searxng and duckduckgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project aims to build a tool that can be run locally, is open-source, and d
 ## Installation
 
 1. Clone the repository - `git clone https://github.com/shadowfax92/fyin.app`
-2. Get Bing API key
+2. Get Bing API key or searxng URL or duckduckgo URL
 3. Get OpenAI API key or [Ollama](https://ollama.com/)
 4. Fill/setup the environment variables (see `sample.env` file, copy it to `.fyin.env` and fill the values))
 5. `cargo run --query "<Question>" -n <number of search results>`
@@ -50,6 +50,11 @@ EMBEDDING_MODEL_NAME="text-embedding-ada-002"
 
 # CHAT_MODEL_NAME="llama3"
 CHAT_MODEL_NAME="gpt-4o"
+
+# Search engine config
+SEARCH_ENGINE="bing" # Options: bing, searxng, duckduckgo
+SEARXNG_ENDPOINT="your-searxng-endpoint"
+DUCKDUCKGO_ENDPOINT="your-duckduckgo-endpoint"
 ```
 
 ### Docker

--- a/sample.env
+++ b/sample.env
@@ -16,3 +16,8 @@ EMBEDDING_MODEL_NAME="text-embedding-ada-002"
 
 # CHAT_MODEL_NAME="llama3"
 CHAT_MODEL_NAME="gpt-4o"
+
+# Search engine config
+SEARCH_ENGINE="bing" # Options: bing, searxng, duckduckgo
+SEARXNG_ENDPOINT="your-searxng-endpoint"
+DUCKDUCKGO_ENDPOINT="your-duckduckgo-endpoint"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,16 @@
-// #![allow(unused_variables)]
 #![allow(dead_code)]
-// #![allow(unused_imports)]
-// #![allow(deprecated)]
 
 #[macro_use]
 extern crate lazy_static;
 
 mod args;
-mod bing;
 mod data;
 mod embedding;
 mod llm;
 mod pretty_print;
 mod scraper;
 mod vector;
+mod search;
 
 use anyhow::Result;
 use clap::Parser;
@@ -76,7 +73,7 @@ async fn prompt(prompt: &str, search_count: usize) -> Result<()> {
 
     // fetch search results
     pretty_print::print_blue("Fetching search results from bing...");
-    bing::fetch_web_pages(request.clone(), search_count).await?;
+    search::fetch_web_pages(request.clone(), search_count).await?;
 
     // scrape content
     pretty_print::print_blue("Scraping content from search results...");


### PR DESCRIPTION
Related to #1

Add support for searxng and duckduckgo search engines.

* Add `SEARCH_ENGINE`, `SEARXNG_ENDPOINT`, and `DUCKDUCKGO_ENDPOINT` variables to `sample.env`.
* Update `README.md` to include instructions for setting `SEARCH_ENGINE` and corresponding API keys/URLs.
* Rename `src/bing.rs` to `src/search.rs`.
* Modify `fetch_web_pages` function in `src/search.rs` to handle `SEARCH_ENGINE` value and add support for searxng and duckduckgo endpoints.
* Update import statement in `src/main.rs` to use `search.rs` instead of `bing.rs`.
* Update `fetch_web_pages` function call in `src/main.rs` to use `search::fetch_web_pages`.